### PR TITLE
Move babel plugin out of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-proposal-function-bind": "^7.0.0-beta.49",
     "@babel/plugin-proposal-function-sent": "^7.0.0-beta.49",
     "@babel/plugin-proposal-json-strings": "^7.0.0-beta.49",
+    "@babel/plugin-proposal-logical-assignment-operators": "^7.0.0-beta.49",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0-beta.49",
     "@babel/plugin-proposal-optional-chaining": "^7.0.0-beta.49",
     "@babel/plugin-proposal-pipeline-operator": "^7.0.0-beta.49",
@@ -59,7 +60,6 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.49",
     "@babel/core": "^7.0.0-beta.49",
-    "@babel/plugin-proposal-logical-assignment-operators": "^7.0.0-beta.49",
     "@babel/preset-env": "^7.0.0-beta.49",
     "@types/babel-core": "^6.25.4",
     "@types/jest": "^23.0.0",


### PR DESCRIPTION
Tried adding this to a project of mine, but got a `Cannot find module` error when running via webpack. Saw that the `@babel/plugin-proposal-logical-assignment-operators` was installed as a dev dependency, unlike the other plugins.